### PR TITLE
All Search Results Screen

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,17 @@
+import { Toaster } from "react-hot-toast";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 import PrivateRoute from "./components/PrivateRoute";
 import PublicRoute from "./components/PublicRoute";
-import Entries from "./pages/Entries/Entries";
-import SignIn from "./pages/SignIn/SignIn";
-import Sidebar from "./pages/Sidebar/Sidebar";
 import ApiProvider from "./contexts/ApiProvider";
 import UserProvider from "./contexts/UserProvider";
-import PrivateEntries from "./pages/PrivateEntries/PrivateEntries";
-import Statistics from "./pages/Statistics/Statistics";
-import UserGroups from "./pages/UserGroups/UserGroups";
-import Group from "./pages/Group/Group";
+import AllSearchResults from "./pages/AllSearchResults/AllSearchResults";
 import CreateGroup from "./pages/CreateGroup/CreateGroup";
-import { Toaster } from "react-hot-toast";
+import Entries from "./pages/Entries/Entries";
+import Group from "./pages/Group/Group";
+import PrivateEntries from "./pages/PrivateEntries/PrivateEntries";
+import Sidebar from "./pages/Sidebar/Sidebar";
+import SignIn from "./pages/SignIn/SignIn";
+import UserGroups from "./pages/UserGroups/UserGroups";
 
 export default function App() {
   return (
@@ -43,7 +43,10 @@ export default function App() {
                           element={<CreateGroup />}
                         />
                         <Route path="/journal" element={<PrivateEntries />} />
-                        <Route path="/statistics" element={<Statistics />} />
+                        <Route
+                          path="/statistics"
+                          element={<AllSearchResults />}
+                        />
                         {/* <Route path="/profile/:userID" element={<Profile />} /> */}
                         {/* <Route path="/settings" element={<Settings />} /> */}
                         <Route path="*" element={<Navigate to="/" />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Group from "./pages/Group/Group";
 import PrivateEntries from "./pages/PrivateEntries/PrivateEntries";
 import Sidebar from "./pages/Sidebar/Sidebar";
 import SignIn from "./pages/SignIn/SignIn";
+import Statistics from "./pages/Statistics/Statistics";
 import UserGroups from "./pages/UserGroups/UserGroups";
 
 export default function App() {
@@ -43,10 +44,8 @@ export default function App() {
                           element={<CreateGroup />}
                         />
                         <Route path="/journal" element={<PrivateEntries />} />
-                        <Route
-                          path="/statistics"
-                          element={<AllSearchResults />}
-                        />
+                        <Route path="/statistics" element={<Statistics />} />
+                        <Route path="/search" element={<AllSearchResults />} />
                         {/* <Route path="/profile/:userID" element={<Profile />} /> */}
                         {/* <Route path="/settings" element={<Settings />} /> */}
                         <Route path="*" element={<Navigate to="/" />} />

--- a/src/assets/IconFilter.tsx
+++ b/src/assets/IconFilter.tsx
@@ -1,9 +1,31 @@
 import { SVGProps } from "react";
+interface FilterProps {
+  filled?: boolean;
+}
 
-export default function IconFilter(props: SVGProps<SVGSVGElement>) {
-  return (
+export default function IconFilter({
+  filled = false,
+  color,
+  ...rest
+}: SVGProps<SVGSVGElement> & FilterProps) {
+  return filled ? (
     <svg
-      {...props}
+      xmlns="http://www.w3.org/2000/svg"
+      width="40"
+      height="40"
+      viewBox="0 0 40 40"
+      fill="none"
+      {...rest}
+    >
+      <circle cx="20" cy="20" r="20" fill="#F7EFD7" />
+      <path
+        d="M18 26V24H22V26H18ZM14 21V19H26V21H14ZM11 16V14H29V16H11Z"
+        fill="#664810"
+      />
+    </svg>
+  ) : (
+    <svg
+      {...rest}
       width="24"
       height="24"
       viewBox="0 0 24 24"
@@ -12,7 +34,7 @@ export default function IconFilter(props: SVGProps<SVGSVGElement>) {
     >
       <path
         d="M10 18V16H14V18H10ZM6 13V11H18V13H6ZM3 8V6H21V8H3Z"
-        fill={props.color}
+        fill={color}
       />
     </svg>
   );

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -6,14 +6,16 @@ export default function BackButton({
   relativeUrl,
   text,
   className = "",
+  state,
 }: {
   relativeUrl: string;
   text: string;
   className?: string;
+  state?: any;
 }) {
   return (
     <Row className={className}>
-      <Link to={relativeUrl}>
+      <Link to={relativeUrl} state={state}>
         <Row className="items-center">
           <img src={LeftArrowIcon} className="max-w-[24px]" />
           <label className="font-normal text-gray-600">{text}</label>

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -1,7 +1,6 @@
 import { Link } from "react-router-dom";
-import Row from "./layout/Row";
 import LeftArrowIcon from "../assets/arrow_left.svg";
-import React from "react";
+import Row from "./layout/Row";
 
 export default function BackButton({
   relativeUrl,
@@ -15,7 +14,7 @@ export default function BackButton({
   return (
     <Row className={className}>
       <Link to={relativeUrl}>
-        <Row>
+        <Row className="items-center">
           <img src={LeftArrowIcon} className="max-w-[24px]" />
           <label className="font-normal text-gray-600">{text}</label>
         </Row>

--- a/src/components/SmallHappinessCard.tsx
+++ b/src/components/SmallHappinessCard.tsx
@@ -15,7 +15,13 @@ interface Action {
  * @param {Happiness} happiness - An object of type `Happiness` which contains the details of a happiness event. It has properties like `value`, `timestamp`, and `author` which contains the `username`.
  * @param {Action[]} actions - An optional array of `Action` objects. This will create buttons as seen in design
  */
-export default function SmallHappinessCard({ happiness, actions = [] }: { happiness: Happiness, actions?: Action[]; }) {
+export default function SmallHappinessCard({
+  happiness,
+  actions = [],
+}: {
+  happiness: Happiness;
+  actions?: Action[];
+}) {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 
@@ -23,36 +29,39 @@ export default function SmallHappinessCard({ happiness, actions = [] }: { happin
 
   return (
     <Card className="p-4">
-      <Row className="items-center">
-        <div className="bg-light_yellow rounded-[4px] w-11 h-11 flex items-center justify-center">
-          <h4 className="text-secondary">{happiness.value}</h4>
+      <Row className="items-center gap-x-2">
+        <div className="flex h-11 w-11 items-center justify-center rounded-[4px] bg-light_yellow">
+          <h4 className="text-secondary">{happiness.value.toFixed(1)}</h4>
         </div>
         <div className="w-1" />
         <Column>
           <p className="text-gray-600">{happiness.author.username}</p>
-          <label className="text-gray-400">{
-            happinessDate < today ?
-              happinessDate.toLocaleDateString("en-us", {
-                month: "long",
-                day: "numeric",
-                year: "numeric"
-              }) : "Today"
-          }</label>
+          <label className="font-normal text-gray-400">
+            {happinessDate < today
+              ? happinessDate.toLocaleDateString("en-us", {
+                  month: "long",
+                  day: "numeric",
+                  year: "numeric",
+                })
+              : "Today"}
+          </label>
         </Column>
         <div className="flex flex-grow" />
         <Row className="gap-3">
-          {actions.map((action) =>
+          {actions.map((action) => (
             <div
-              className="px-3 py-1 bg-gray-50 rounded-[4px] hover:cursor-pointer"
+              className="rounded-[4px] bg-gray-50 px-3 py-1 hover:cursor-pointer"
               onClick={action.onClick}
             >
               <label className="text-gray-400">{action.label}</label>
             </div>
-          )}
+          ))}
         </Row>
       </Row>
       <div className="h-4" />
-      <p className="text-gray-600 max-lines-3">{happiness.comment}</p>
+      <p className="max-lines-3 font-normal text-gray-600">
+        {happiness.comment}
+      </p>
     </Card>
   );
 }

--- a/src/components/SmallHappinessCard.tsx
+++ b/src/components/SmallHappinessCard.tsx
@@ -29,7 +29,7 @@ export default function SmallHappinessCard({
 
   return (
     <Card className="p-4">
-      <Row className="items-center gap-x-2">
+      <Row className="items-center gap-x-1">
         <div className="flex h-11 w-11 items-center justify-center rounded-[4px] bg-light_yellow">
           <h4 className="text-secondary">{happiness.value.toFixed(1)}</h4>
         </div>

--- a/src/pages/AllSearchResults/AllSearchResults.tsx
+++ b/src/pages/AllSearchResults/AllSearchResults.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from "react";
+import { useInView } from "react-intersection-observer";
+import { useInfiniteQuery, useQuery } from "react-query";
+import BackButton from "../../components/BackButton";
+import SmallHappinessCard from "../../components/SmallHappinessCard";
+import Spinner from "../../components/Spinner";
+import Column from "../../components/layout/Column";
+import EntryTextSkeleton from "../../components/skeletons/EntryTextSkeleton";
+import { QueryKeys } from "../../constants";
+import { useApi } from "../../contexts/ApiProvider";
+import { Happiness, HappinessPagination } from "../../data/models/Happiness";
+import {
+  createSearchQuery,
+  formatDate,
+  parseYYYYmmddFormat,
+} from "../../utils";
+import SearchBar from "../Statistics/SearchBar";
+export default function AllSearchResults() {
+  const [text, setText] = useState("");
+  const [startValue, setStartValue] = useState(0);
+  const [endValue, setEndValue] = useState(10);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+  const [bottomRef, bottomInView] = useInView();
+
+  const { api } = useApi();
+
+  const { data: numResults, isLoading: isLoadingNum } = useQuery({
+    // Find the number of total matching results
+    queryKey: [
+      QueryKeys.FETCH_HAPPINESS_COUNT,
+      { start: formatDate(parseYYYYmmddFormat(startDate)) },
+      { end: formatDate(parseYYYYmmddFormat(endDate)) },
+      { low: startValue },
+      { high: endValue },
+      { text: text },
+    ],
+    queryFn: async () => {
+      const query = createSearchQuery(
+        text,
+        startDate,
+        endDate,
+        startValue,
+        endValue,
+      );
+      const res = await api.get<Number>("/happiness/search/count", query);
+      return res.data;
+    },
+  });
+  const fetchResults = async ({
+    pageParam = 0,
+  }): Promise<HappinessPagination> => {
+    const query = createSearchQuery(
+      text,
+      startDate,
+      endDate,
+      startValue,
+      endValue,
+    );
+    query.count = 10;
+    query.page = pageParam;
+    const res = await api.get<Happiness[]>("/happiness/search", query);
+    return {
+      data: res.data,
+      page: pageParam,
+    };
+  };
+  const {
+    data: searchResults,
+    isLoading: isSearchLoading,
+    fetchNextPage,
+  } = useInfiniteQuery({
+    queryKey: [
+      QueryKeys.FETCH_HAPPINESS,
+      QueryKeys.INFINITE,
+      { start: formatDate(parseYYYYmmddFormat(startDate)) },
+      { end: formatDate(parseYYYYmmddFormat(endDate)) },
+      { low: startValue },
+      { high: endValue },
+      { count: 5 },
+      { text: text },
+    ],
+    queryFn: fetchResults,
+    getNextPageParam: (lastPage) => lastPage.page + 1,
+  });
+
+  // combine all entries in React Query pages object
+  const allEntries = useMemo(
+    () =>
+      searchResults?.pages.reduce(
+        (acc: Happiness[], page) => [...acc, ...page.data],
+        [],
+      ),
+    [searchResults],
+  );
+
+  useEffect(() => {
+    if (bottomInView) {
+      fetchNextPage();
+    }
+  }, [bottomInView]);
+
+  return (
+    <Column className="mx-8 mt-16 gap-6">
+      <BackButton relativeUrl="statistics" text="Back to Your Stats" />
+      <SearchBar
+        text={text}
+        setText={setText}
+        startValue={startValue}
+        setStartValue={setStartValue}
+        endValue={endValue}
+        setEndValue={setEndValue}
+        startDate={startDate}
+        setStartDate={setStartDate}
+        endDate={endDate}
+        setEndDate={setEndDate}
+        showResultsPreview={false}
+      />
+      {isLoadingNum ? (
+        <EntryTextSkeleton />
+      ) : (
+        <p className="text-gray-400">
+          <span className={"font-bold text-gray-400"}>
+            {numResults?.number}
+          </span>{" "}
+          entries found
+        </p>
+      )}
+      <Column className="gap-4">
+        {allEntries?.map((happiness) => (
+          <SmallHappinessCard happiness={happiness} />
+        ))}
+        {allEntries?.length !== 0 && (
+          <div ref={bottomRef}>
+            <Spinner className="m-3 min-h-[100px]" text="Loading entries..." />
+          </div>
+        )}
+      </Column>
+    </Column>
+  );
+}

--- a/src/pages/Statistics.tsx
+++ b/src/pages/Statistics.tsx
@@ -1,6 +1,0 @@
-
-export default function Statistics() {
-  return (
-    <div>Statistics</div>
-  );
-}

--- a/src/pages/Statistics/SearchBar.tsx
+++ b/src/pages/Statistics/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQueries } from "react-query";
 import { useNavigate } from "react-router-dom";
 import IconClose from "../../assets/IconClose";
@@ -47,6 +47,15 @@ export default function SearchBar({
   const [filterShowing, setFilterShowing] = useState(false);
   const [resultsShowing, setResultsShowing] = useState(true);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState(-1);
+  const iconFilled = useMemo<boolean>(
+    () =>
+      filterShowing ||
+      startValue !== 0 ||
+      endValue !== 10 ||
+      startDate !== "" ||
+      endDate !== "",
+    [filterShowing, startValue, endValue, startDate, endDate],
+  );
 
   const navigate = useNavigate();
 
@@ -156,7 +165,7 @@ export default function SearchBar({
     <Column className="relative z-50 w-full gap-4">
       {/* Search bar */}
       <Row
-        className={`items-center rounded-[50px] border-1 border-gray-300 px-6 py-3 hover:border-gray-400 ${
+        className={`items-center rounded-[50px] border-1 border-gray-300 px-6 hover:border-gray-400 ${
           isFocused
             ? "border-yellow shadow-form-selected hover:border-yellow"
             : ""
@@ -168,7 +177,7 @@ export default function SearchBar({
             setText(e.target.value);
           }}
           placeholder="Search for keywords"
-          className="w-auto flex-grow focus:outline-none"
+          className="my-3 w-auto flex-grow focus:outline-none"
           onBlur={() => {
             setIsFocused(false);
           }}
@@ -176,16 +185,17 @@ export default function SearchBar({
             setIsFocused(true);
           }}
         />
-        <Row className="gap-4">
+        <Row className={`items-center ${iconFilled ? " gap-2" : " gap-4"}`}>
           <IconFilter
             color="#808080"
-            className="hover:cursor-pointer"
+            className={`hover:cursor-pointer`}
             onClick={handleToggleFilter}
+            filled={iconFilled}
           />
           {text.length !== 0 && (
             <IconClose
               color="#808080"
-              className="hover:cursor-pointer"
+              className="my-3 hover:cursor-pointer"
               onClick={() => {
                 setText("");
                 setResultsShowing(false);

--- a/src/pages/Statistics/SearchBar.tsx
+++ b/src/pages/Statistics/SearchBar.tsx
@@ -45,7 +45,7 @@ export default function SearchBar({
 }) {
   const [isFocused, setIsFocused] = useState(false);
   const [filterShowing, setFilterShowing] = useState(false);
-  const [resultsShowing, setResultsShowing] = useState(false);
+  const [resultsShowing, setResultsShowing] = useState(true);
   const [selectedEntryIndex, setSelectedEntryIndex] = useState(-1);
 
   const navigate = useNavigate();
@@ -307,6 +307,19 @@ export default function SearchBar({
               className={`${
                 !count || count?.number === 0 ? "" : "underline"
               } text-sm text-gray-400 hover:cursor-pointer`}
+              onClick={() => {
+                if (count && count.number !== 0) {
+                  navigate("/search", {
+                    state: {
+                      startDate: startDate,
+                      endDate: endDate,
+                      startValue: startValue,
+                      endValue: endValue,
+                      text: text,
+                    },
+                  });
+                }
+              }}
             >
               {!count || count?.number === 0
                 ? "No search results"

--- a/src/pages/Statistics/Statistics.tsx
+++ b/src/pages/Statistics/Statistics.tsx
@@ -1,13 +1,17 @@
 import { useState } from "react";
+import { useLocation } from "react-router-dom";
 import Column from "../../components/layout/Column";
 import SearchBar from "./SearchBar";
 
 export default function Statistics() {
-  const [text, setText] = useState("");
-  const [startValue, setStartValue] = useState(0);
-  const [endValue, setEndValue] = useState(10);
-  const [startDate, setStartDate] = useState("");
-  const [endDate, setEndDate] = useState("");
+  const location = useLocation();
+  const [text, setText] = useState(location?.state?.text ?? "");
+  const [startValue, setStartValue] = useState(
+    location?.state?.startValue ?? 0,
+  );
+  const [endValue, setEndValue] = useState(location?.state?.endValue ?? 10);
+  const [startDate, setStartDate] = useState(location?.state?.startDate ?? "");
+  const [endDate, setEndDate] = useState(location?.state?.endDate ?? "");
 
   return (
     <Column className="w-3/4 items-stretch gap-8 px-8 py-24">

--- a/src/pages/Statistics/Statistics.tsx
+++ b/src/pages/Statistics/Statistics.tsx
@@ -1,11 +1,29 @@
+import { useState } from "react";
 import Column from "../../components/layout/Column";
 import SearchBar from "./SearchBar";
 
 export default function Statistics() {
+  const [text, setText] = useState("");
+  const [startValue, setStartValue] = useState(0);
+  const [endValue, setEndValue] = useState(10);
+  const [startDate, setStartDate] = useState("");
+  const [endDate, setEndDate] = useState("");
+
   return (
     <Column className="w-3/4 items-stretch gap-8 px-8 py-24">
       <h1>Statistics</h1>
-      <SearchBar />
+      <SearchBar
+        text={text}
+        setText={setText}
+        startValue={startValue}
+        setStartValue={setStartValue}
+        endValue={endValue}
+        setEndValue={setEndValue}
+        startDate={startDate}
+        setStartDate={setStartDate}
+        endDate={endDate}
+        setEndDate={setEndDate}
+      />
     </Column>
   );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -116,8 +116,12 @@ export function useOnline() {
   const [isOnline, setIsOnline] = useState(navigator.onLine);
 
   useEffect(() => {
-    const onlineHanlder = () => { setIsOnline(true); };
-    const offlineHanlder = () => { setIsOnline(false); };
+    const onlineHanlder = () => {
+      setIsOnline(true);
+    };
+    const offlineHanlder = () => {
+      setIsOnline(false);
+    };
     window.addEventListener("online", onlineHanlder);
     window.addEventListener("offline", offlineHanlder);
 
@@ -128,4 +132,34 @@ export function useOnline() {
   });
 
   return isOnline;
+}
+
+export function createSearchQuery(
+  text: string,
+  start: string,
+  end: string,
+  startValue: number,
+  endValue: number,
+): Record<string, string | number> {
+  const query: Record<string, any> = {};
+  if (text !== "") {
+    query.text = text;
+  }
+  if (!isNaN(new Date(start).getTime())) {
+    query.start = formatDate(parseYYYYmmddFormat(start));
+  }
+  if (!isNaN(new Date(end).getTime())) {
+    query.end = formatDate(parseYYYYmmddFormat(end));
+  }
+  if (query.start && !query.end) {
+    query.end = formatDate(new Date());
+  }
+  if (query.end && !query.start) {
+    query.start = "2000-01-01";
+  }
+  if (startValue !== 0 || endValue !== 10) {
+    query.low = startValue;
+    query.high = endValue;
+  }
+  return query;
 }


### PR DESCRIPTION
This PR adds the all search results screen. It uses an infinite scroll to display all possible search results for a given query. It also links with the statistics page using navigation state so you can go back and forth without losing search data. I also colored in the filter icon depending on if filters are applied.

Screenshot:
<img width="1163" alt="image" src="https://github.com/jonathanjma/happiness-app-frontend/assets/58796478/e375393f-56f8-407d-84bd-ffea8cf3c310">
