### PR TITLE
Fix search bar and weekly calendar view issues

### DIFF
--- a/src/components/HappinessCalendar.tsx
+++ b/src/components/HappinessCalendar.tsx
@@ -44,8 +44,8 @@ export default function HappinessCalendar({
 
     const dayToAdd = new Date(startDate);
     for (let i = 0; i <= 6; i++) {
-      dayToAdd.setDate(startDate.getDate() + i);
       days.push(new Date(dayToAdd));
+      dayToAdd.setDate(dayToAdd.getDate() + 1);
     }
   }
 

--- a/src/pages/Statistics/SearchBar.tsx
+++ b/src/pages/Statistics/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { createRef, useEffect, useMemo, useState } from "react";
 import { useQueries } from "react-query";
 import { useNavigate } from "react-router-dom";
 import IconClose from "../../assets/IconClose";
@@ -57,6 +57,8 @@ export default function SearchBar({
     [filterShowing, startValue, endValue, startDate, endDate],
   );
 
+  const searchInput = createRef<HTMLInputElement>();
+
   const navigate = useNavigate();
 
   // handle showing and hiding filter and results
@@ -71,6 +73,7 @@ export default function SearchBar({
   const handleShowResults = () => {
     setFilterShowing(false);
     setResultsShowing(true);
+    searchInput.current?.focus();
   };
 
   const { api } = useApi();
@@ -184,6 +187,7 @@ export default function SearchBar({
           onFocus={() => {
             setIsFocused(true);
           }}
+          ref={searchInput}
         />
         <Row className={`items-center ${iconFilled ? " gap-2" : " gap-4"}`}>
           <IconFilter
@@ -268,7 +272,7 @@ export default function SearchBar({
       )}
 
       {/* Results preview */}
-      {showResultsPreview && resultsShowing && (
+      {showResultsPreview && resultsShowing && isFocused && (
         <Card className="absolute left-0 right-0 z-50 translate-y-16 border-gray-200 bg-white">
           {data && data.length === 0 ? (
             <p className="mx-4 my-3 text-gray-400">

--- a/src/pages/Statistics/Statistics.tsx
+++ b/src/pages/Statistics/Statistics.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { useQuery, useQueryClient } from "react-query";
 import { useLocation } from "react-router-dom";
-import SearchBar from "./SearchBar";
+import ExpandLeftIcon from "../../assets/ExpandLeftIcon";
+import ExpandRightIcon from "../../assets/ExpandRightIcon";
 import DateRangeSwitcher from "../../components/DateRangeSwitcher";
 import Graph from "../../components/Graph";
 import HappinessCalendar from "../../components/HappinessCalendar";
@@ -12,9 +13,8 @@ import { useApi } from "../../contexts/ApiProvider";
 import { useUser } from "../../contexts/UserProvider";
 import { Happiness } from "../../data/models/Happiness";
 import { formatDate, useWindowDimensions } from "../../utils";
+import SearchBar from "./SearchBar";
 import Stat from "./Stat";
-import ExpandLeftIcon from "../../assets/ExpandLeftIcon";
-import ExpandRightIcon from "../../assets/ExpandRightIcon";
 
 /**
  * The page for displaying statistics for the current user
@@ -57,8 +57,9 @@ export default function Statistics() {
   );
 
   useEffect(() => {
-    // @ts-ignore
-    window.HSOverlay.open(document.querySelector("#show-happiness-modal"));
+    if (viewingEntry) {
+      window.HSOverlay.open(document.querySelector("#show-happiness-modal"));
+    }
   }, [viewingEntry]);
 
   const { width, height } = useWindowDimensions();

--- a/src/pages/UserSettings/UserSettings.tsx
+++ b/src/pages/UserSettings/UserSettings.tsx
@@ -49,9 +49,6 @@ export default function UserSettings() {
   };
 
   // for recovery phrase modal
-  const [recoveryPhrase, setRecoveryPhrase] = useState("");
-  const [recoveryPhraseState, setRecoveryPhraseState] = useState("");
-  const [password, setPassword] = useState("");
   const [triedSubmit, setTriedSubmit] = useState(false);
 
   const [emailTimeNetworkingState, setEmailTimeNetworkingState] = useState(


### PR DESCRIPTION
This pull request fixes two issues in the codebase:

1. Issue #28: The search bar in the statistics page was automatically opening when the page loaded. This behavior has been fixed by adding a focus event to the search input field.

2. Issue #29: The weekly calendar view was showing wrong dates on the year boundary when the data spanned two different years. This issue has been resolved by updating the logic to correctly calculate the days of the week.

Also deleted unused variables for code cleanup. This PR also includes a fix for Statistics page where on a fresh load it would crash.