### PR TITLE
Fix issue with decrementing notification time

### DIFF
--- a/src/pages/UserSettings/UserSettings.tsx
+++ b/src/pages/UserSettings/UserSettings.tsx
@@ -31,9 +31,6 @@ export default function UserSettings() {
     .find((s) => s.key === "notify")
     ?.value.split(" ")[0];
 
-  useEffect(() => {
-    console.log(`userTime: ${userTime}`);
-  }, [userTime]);
   const [emailTime, setEmailTime] = useState(
     userTime ? convertToLocalTime(userTime) : "09:00",
   );

--- a/src/pages/UserSettings/UserSettings.tsx
+++ b/src/pages/UserSettings/UserSettings.tsx
@@ -30,6 +30,10 @@ export default function UserSettings() {
   const userTime = user!.settings
     .find((s) => s.key === "notify")
     ?.value.split(" ")[0];
+
+  useEffect(() => {
+    console.log(`userTime: ${userTime}`);
+  }, [userTime]);
   const [emailTime, setEmailTime] = useState(
     userTime ? convertToLocalTime(userTime) : "09:00",
   );
@@ -113,7 +117,7 @@ export default function UserSettings() {
     onSuccess: (data: SettingShort) => {
       updateUserSetting({
         ...data,
-        value: convertToLocalTime(data.value.split(" ")[0]),
+        value: data.value,
       });
       setHasEmailAlerts(data.enabled);
       setEmailTime(convertToLocalTime(data.value.split(" ")[0]).split(" ")[0]);


### PR DESCRIPTION
This pull request fixes an issue where navigating between the settings page would decrement the notification time. The issue was caused by incorrect handling of the user's time settings. With this fix, the notification time will no longer be decremented when navigating between settings pages.