### PR TITLE
Final time zone fix

### DIFF
--- a/src/pages/UserSettings/UserSettings.tsx
+++ b/src/pages/UserSettings/UserSettings.tsx
@@ -23,7 +23,7 @@ export default function UserSettings() {
   const { api } = useApi();
   const [hasEmailAlerts, setHasEmailAlerts] = useState(
     user!.settings.find((s) => s.key === "notify" && s.enabled === true) !==
-    undefined,
+      undefined,
   );
   // we only care about the time of this date
   const userTime = user!.settings
@@ -98,8 +98,9 @@ export default function UserSettings() {
       api
         .post<SettingShort>("/user/settings/", {
           key: "notify",
-          value: `${emailTime} ${Intl.DateTimeFormat().resolvedOptions().timeZone
-            }`,
+          value: `${emailTime} ${
+            Intl.DateTimeFormat().resolvedOptions().timeZone
+          }`,
           enabled: enabled,
         })
         .then((res) => res.data),
@@ -361,8 +362,9 @@ export default function UserSettings() {
           {changePasswordState &&
             changePasswordState !== Constants.CONFIRM_PASSWORD_ERROR && (
               <label
-                className={`font-normal ${changePasswordError ? "text-error" : "text-gray-400"
-                  }`}
+                className={`font-normal ${
+                  changePasswordError ? "text-error" : "text-gray-400"
+                }`}
               >
                 {changePasswordState}
               </label>

--- a/src/pages/UserSettings/UserSettings.tsx
+++ b/src/pages/UserSettings/UserSettings.tsx
@@ -15,7 +15,6 @@ import { Constants } from "../../constants";
 import { useApi } from "../../contexts/ApiProvider";
 import { useUser } from "../../contexts/UserProvider";
 import { SettingShort } from "../../data/models/Setting";
-import { convertToLocalTime, get24HourTimeAsUTC } from "../../utils";
 import DeleteAccountModals from "./DeleteAccountModals";
 import RecoveryPhraseModal from "./RecoveryPhraseModal";
 
@@ -24,16 +23,14 @@ export default function UserSettings() {
   const { api } = useApi();
   const [hasEmailAlerts, setHasEmailAlerts] = useState(
     user!.settings.find((s) => s.key === "notify" && s.enabled === true) !==
-      undefined,
+    undefined,
   );
   // we only care about the time of this date
   const userTime = user!.settings
     .find((s) => s.key === "notify")
     ?.value.split(" ")[0];
 
-  const [emailTime, setEmailTime] = useState(
-    userTime ? convertToLocalTime(userTime) : "09:00",
-  );
+  const [emailTime, setEmailTime] = useState(userTime ?? "09:00");
   const [email, setEmail] = useState("");
   const [changeEmailState, setChangeEmailState] = useState("");
 
@@ -85,9 +82,7 @@ export default function UserSettings() {
       setIsFirstRender(false);
     } else {
       clearTimeout(updateEmailTimeout.current);
-      // was getting weird TypeScript errors so I needed to prepend window.
-      // see https://stackoverflow.com/a/55550147
-      updateEmailTimeout.current = window.setTimeout(updateEmailHandler, 500);
+      updateEmailTimeout.current = setTimeout(updateEmailHandler, 500);
     }
   }, [emailTime]);
 
@@ -99,15 +94,12 @@ export default function UserSettings() {
 
   // Updating email alerts setting
   const updateEmailAlerts = useMutation({
-    // Only way to have optional parameters for mutationFn
-    // https://github.com/TanStack/query/issues/4264#issuecomment-1268054812
     mutationFn: (enabled: boolean) =>
       api
         .post<SettingShort>("/user/settings/", {
           key: "notify",
-          value: `${get24HourTimeAsUTC(emailTime)} ${
-            Intl.DateTimeFormat().resolvedOptions().timeZone
-          }`,
+          value: `${emailTime} ${Intl.DateTimeFormat().resolvedOptions().timeZone
+            }`,
           enabled: enabled,
         })
         .then((res) => res.data),
@@ -117,7 +109,7 @@ export default function UserSettings() {
         value: data.value,
       });
       setHasEmailAlerts(data.enabled);
-      setEmailTime(convertToLocalTime(data.value.split(" ")[0]).split(" ")[0]);
+      setEmailTime(data.value.split(" ")[0]);
       setEmailTimeNetworkingState(Constants.FINISHED_MUTATION_TEXT);
     },
     onError: () => {
@@ -369,9 +361,8 @@ export default function UserSettings() {
           {changePasswordState &&
             changePasswordState !== Constants.CONFIRM_PASSWORD_ERROR && (
               <label
-                className={`font-normal ${
-                  changePasswordError ? "text-error" : "text-gray-400"
-                }`}
+                className={`font-normal ${changePasswordError ? "text-error" : "text-gray-400"
+                  }`}
               >
                 {changePasswordState}
               </label>


### PR DESCRIPTION
Previously, even though timings appeared to be working properly on the frontend, they were actually being sent to the backend as UTC. This shouldn't be the case because the time includes the user's time zone. So this fixes it so the state of the frontend exactly matches the time stored on the backend.